### PR TITLE
Alerts: Add Auto-Hammers

### DIFF
--- a/modules/Alerts.lua
+++ b/modules/Alerts.lua
@@ -48,6 +48,8 @@ combatLogMap.SPELL_CAST_SUCCESS = {
 	[54711] = "Repair",  -- Scrapbot
 	[67826] = "Repair",  -- Jeeves
 	[157066] = "Repair", -- Walter
+	[199109] = "Repair", -- Regular Auto-Hammer
+	[200205] = "Repair", -- Reaves Auto-Hammer mode	
 	-- Summoning
 	[698] = "Summon", -- Ritual of Summoning (Warlock)
 	-- Misdirects


### PR DESCRIPTION
I think the Reaves Auto-Hammer mode will get incorrectly attributed to the Reaves that's being transformed, instead of the owner of that Reaves. src and dst both seem to be it.
Might need separate tracking to determine the actual owner, I have no clue how to do that though.
But as it is, at least there'll be an alert. :)