### PR TITLE
fix: Add API compatibility for TBC Anniversary and newer Classic clients

### DIFF
--- a/modules/Alerts.lua
+++ b/modules/Alerts.lua
@@ -18,7 +18,7 @@ local classColors = oRA.classColors
 local combatLogHandler = CreateFrame("Frame")
 local GetOptions
 
-local LE_PARTY_CATEGORY_INSTANCE = _G.LE_PARTY_CATEGORY_INSTANCE
+local LE_PARTY_CATEGORY_INSTANCE = _G.LE_PARTY_CATEGORY_INSTANCE or 2
 local bit_band, bit_bor = bit.band, bit.bor
 local tconcat = table.concat
 

--- a/modules/Consumables.lua
+++ b/modules/Consumables.lua
@@ -3,6 +3,9 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 	return
 end
 
+-- API Compatibility for newer Classic clients (TBC Anniversary, etc.)
+local LE_PARTY_CATEGORY_INSTANCE = LE_PARTY_CATEGORY_INSTANCE or 2
+
 local _, scope = ...
 local oRA = scope.addon
 local module = oRA:NewModule("Consumables", "AceTimer-3.0")

--- a/modules/Cooldowns/Cooldowns.lua
+++ b/modules/Cooldowns/Cooldowns.lua
@@ -3,6 +3,9 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 	return
 end
 
+-- API Compatibility for newer Classic clients (TBC Anniversary, etc.)
+local LE_PARTY_CATEGORY_INSTANCE = LE_PARTY_CATEGORY_INSTANCE or 2
+
 --------------------------------------------------------------------------------
 -- Setup
 --
@@ -228,7 +231,7 @@ local talentCooldowns = {
 	[19237] = function(info) -- Outlaw: Retractable Hook
 		addMod(info.guid, 195457, 30) -- Grappling Hook
 	end,
-	[19237] = function(info) -- Outlaw: Blinding Powder
+	[21188] = function(info) -- Outlaw: Blinding Powder
 		addMod(info.guid, 2094, 30) -- Blind
 	end,
 	[22336] = function(info) -- Subtlety: Enveloping Shadows

--- a/modules/Invite.lua
+++ b/modules/Invite.lua
@@ -3,6 +3,10 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 	return
 end
 
+-- API Compatibility for newer Classic clients (TBC Anniversary, etc.)
+local GuildRoster = GuildRoster or (C_GuildInfo and C_GuildInfo.GuildRoster)
+local LE_PARTY_CATEGORY_INSTANCE = LE_PARTY_CATEGORY_INSTANCE or 2
+
 local addonName, scope = ...
 local oRA = scope.addon
 local module = oRA:NewModule("Invite", "AceTimer-3.0")

--- a/modules/ReadyCheck.lua
+++ b/modules/ReadyCheck.lua
@@ -3,6 +3,12 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 	return
 end
 
+-- API Compatibility for newer Classic clients (TBC Anniversary, etc.)
+local SOUND_LABEL = SOUND_LABEL or SOUND or "Sound"
+local INLINE_TANK_ICON = INLINE_TANK_ICON or "|TInterface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES:16:16:0:0:64:64:0:19:22:41|t"
+local INLINE_HEALER_ICON = INLINE_HEALER_ICON or "|TInterface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES:16:16:0:0:64:64:20:39:1:20|t"
+local INLINE_DAMAGER_ICON = INLINE_DAMAGER_ICON or "|TInterface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES:16:16:0:0:64:64:20:39:22:41|t"
+
 local _, scope = ...
 local oRA = scope.addon
 local module = oRA:NewModule("ReadyCheck", "AceTimer-3.0")

--- a/oRA3.lua
+++ b/oRA3.lua
@@ -4,6 +4,12 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 	return
 end
 
+-- API Compatibility for newer Classic clients (TBC Anniversary, etc.)
+local IsAddOnLoaded = IsAddOnLoaded or (C_AddOns and C_AddOns.IsAddOnLoaded)
+local GuildRoster = GuildRoster or (C_GuildInfo and C_GuildInfo.GuildRoster) or function() end
+local GuildControlGetNumRanks = GuildControlGetNumRanks or (C_GuildInfo and C_GuildInfo.GuildControlGetNumRanks) or function() return 0 end
+local GuildControlGetRankName = GuildControlGetRankName or (C_GuildInfo and C_GuildInfo.GuildControlGetRankName) or function() return "" end
+
 local addonName, scope = ...
 local addon = LibStub("AceAddon-3.0"):NewAddon(addonName, "AceTimer-3.0")
 scope.addon = addon
@@ -150,8 +156,8 @@ local function colorize(input) return string.format("|cfffed000%s|r", input) end
 local options = {
 	name = "oRA",
 	type = "group",
-	get = function(info) return db[info[#info]] end,
-	set = function(info, value) db[info[#info]] = value end,
+	get = function(info) return db and db[info[#info]] end,
+	set = function(info, value) if db then db[info[#info]] = value end end,
 	args = {
 		general = {
 			order = 1,
@@ -296,7 +302,7 @@ function addon:OnInitialize()
 	options.args.general.args.profileOptions.args.desc.fontSize = "medium"
 
 	local function OnRaidHide()
-		if addon:IsEnabled() and db.toggleWithRaid then
+		if addon:IsEnabled() and db and db.toggleWithRaid then
 			addon:HideUIPanel()
 		end
 	end
@@ -306,7 +312,7 @@ function addon:OnInitialize()
 	end
 
 	RaidFrame:HookScript("OnShow", function()
-		if addon:IsEnabled() and db.toggleWithRaid then
+		if addon:IsEnabled() and db and db.toggleWithRaid then
 			addon:ShowUIPanel()
 		end
 		if addon.rehookAfterRaidUILoad and IsAddOnLoaded("Blizzard_RaidUI") then

--- a/oRA3.toc
+++ b/oRA3.toc
@@ -1,6 +1,8 @@
-## Interface: 20501
-## Interface-BCC: 20501
-## Interface-Classic: 11307
+## Interface: 11507
+## Interface-Classic: 11507
+## Interface-BCC: 20504
+## Interface-Wrath: 30403
+## Interface-Cata: 40401
 ## Title: oRA3
 ## Notes: Raid and Party Assist
 ## Notes-zhCN: Raid and Party Assist


### PR DESCRIPTION
Add API compatibility shims for newer Classic clients (TBC Anniversary, Cataclysm Classic) where several Blizzard APIs have been moved to new namespaces or renamed.

Issues Fixed:
- "attempt to index upvalue 'db' (a nil value)" - options accessed before init
- "attempt to call global 'IsAddOnLoaded' (a nil value)" - moved to C_AddOns
- "attempt to call global 'GuildRoster' (a nil value)" - moved to C_GuildInfo
- "bad argument #1 to 'format' (string expected, got nil)" - SOUND_LABEL missing
- Duplicate talent ID 19237 bug (Rogue Blinding Powder should be 21188)

API Compatibility Added:
- IsAddOnLoaded -> C_AddOns.IsAddOnLoaded
- GuildRoster -> C_GuildInfo.GuildRoster
- GuildControlGetNumRanks -> C_GuildInfo.GuildControlGetNumRanks
- GuildControlGetRankName -> C_GuildInfo.GuildControlGetRankName
- LE_PARTY_CATEGORY_INSTANCE fallback (value: 2)
- SOUND_LABEL, INLINE_TANK_ICON, INLINE_HEALER_ICON, INLINE_DAMAGER_ICON fallbacks

TOC Updates:
- Classic Era: 11507, TBC: 20504, Wrath: 30403, Cata: 40401